### PR TITLE
attach background style to html, not div

### DIFF
--- a/layouts/blog.vue
+++ b/layouts/blog.vue
@@ -20,7 +20,7 @@
 </template>
 
 <style>
-.wholething {
+html {
   background-color: #000000;
 }
 h1,


### PR DESCRIPTION
Since the background color style was attached to the div, blogpost/{slug} would not have a full background color if the content was < 100vh. This PR adds the style to html directly.